### PR TITLE
refactor: use import type for type-only imports

### DIFF
--- a/src/interfaces/IExtensionContext.ts
+++ b/src/interfaces/IExtensionContext.ts
@@ -1,0 +1,9 @@
+import type { Disposable } from 'vscode';
+
+export interface IExtensionContext {
+  /**
+   * An array to which disposables can be added. When this extension is
+   * deactivated the disposables will be disposed.
+   */
+  readonly subscriptions: Disposable[];
+}


### PR DESCRIPTION
- Updated IExtensionContext.ts to use import type for type-only imports as per ESLint warning\n- Improves code consistency and better signals intent